### PR TITLE
persist event to avoid event.nativeEvent null in setState

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ class Ticker extends Component {
     });
   }
   handleMeasure = e => {
+    e.persist();
     this.setState(state => {
       if(state.measured) {
         return null;


### PR DESCRIPTION
This fixes `TypeError: null is not an object (evaluating 'e.nativeEvent.layout')` in case setState is called after event has been put back in event pool. React does not guarantee you can read event attributes in a setState with update fn.