### PR TITLE
quick-fix for RN 0.61.*

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ class Ticker extends Component {
     fontSize: StyleSheet.flatten(this.props.textStyle).fontSize,
   };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({
       fontSize: StyleSheet.flatten(nextProps.textStyle).fontSize,
     });
@@ -170,7 +170,7 @@ class Tick extends Component {
       });
     }
   }
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.height !== this.props.height) {
       this.setState({
         animation: new Animated.Value(


### PR DESCRIPTION
Deprecated method `componentWillReceiveProps` was renamed to `UNSAFE_componentWillReceiveProps` in React 16.9.* which use used in react-native 0.61+