### PR TITLE
Fix updating animated value

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,28 +159,24 @@ class Tick extends Component {
   componentDidMount() {
     // If we first render then don't do a mounting animation
     if (this.props.height !== 0) {
-      this.setState({
-        animation: new Animated.Value(
-          getPosition({
-            text: this.props.text,
-            items: this.props.rotateItems,
-            height: this.props.height,
-          }),
-        ),
-      });
+      this.state.animation.setValue(
+        getPosition({
+          text: this.props.text,
+          items: this.props.rotateItems,
+          height: this.props.height,
+        })
+      );
     }
   }
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.height !== this.props.height) {
-      this.setState({
-        animation: new Animated.Value(
-          getPosition({
-            text: nextProps.text,
-            items: nextProps.rotateItems,
-            height: nextProps.height,
-          }),
-        ),
-      });
+      this.state.animation.setValue(
+        getPosition({
+          text: nextProps.text,
+          items: nextProps.rotateItems,
+          height: nextProps.height,
+        })
+      );
     }
   }
   componentDidUpdate(prevProps) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ticker",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "React Native Number Ticker",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Didn't test my previous fix, so it only fixed half of the issue.

There is problem with overriding new instance of `Animated.Value`
```js
this.setState({ animation: new Animated.Value(...) });
```
The value will get updated, but `Animated.View` will not update it's position, so the ticker displays only `00`.
With this change, it updates the value once `height` is available and correctly shows the input `text` number in ticker.