### PR TITLE
Move dependencies to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ yarn add react-native-ticker
 npm install react-native-ticker
 ```
 
+Install react-native-reanimated.
+
+```
+yarn add react-native-reanimated
+npm install react-native-reanimated
+```
+
 As of V3 we only support the children prop now.
 
 ```js

--- a/package.json
+++ b/package.json
@@ -26,12 +26,11 @@
   "devDependencies": {
     "@types/react": "^16.9.11",
     "@types/react-native": "^0.60.22",
-    "react": "^16.9.0",
-    "react-native": "0.61.5",
     "typescript": "^3.7.2"
   },
-  "dependencies": {
+  "peerDependencies": {
+    "react": "^16.9.0",
+    "react-native": "^0.61.5",
     "react-native-reanimated": "^1.4.0"
-  },
-  "peerDependencies": {}
+  }
 }


### PR DESCRIPTION
In order to have consistent versions between these dependencies and the ones installed in the user's project it would be better to have theme as peer dependencies (especially react-native-reanimated).

In some cases it helps when one has older versions.