### PR TITLE
Add container style prop

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -3,6 +3,7 @@ import {
   StyleSheet,
   Text,
   View,
+  ViewStyle,
   TextStyle,
   TextProps,
   I18nManager,
@@ -50,6 +51,7 @@ const getPosition = ({
 
 interface Props {
   duration?: number;
+  containerStyle?: ViewStyle;
   textStyle?: TextStyle;
   textProps?: TextProps;
   additionalDisplayItems?: string[];
@@ -146,7 +148,7 @@ const TickItem = ({
   );
 };
 
-const Ticker = ({ duration = 250, textStyle, textProps, children }: Props) => {
+const Ticker = ({ duration = 250, containerStyle, textStyle, textProps, children }: Props) => {
   const [measured, setMeasured] = useState<boolean>(false);
 
   const measureMap = useRef<MeasureMap>({});
@@ -178,7 +180,7 @@ const Ticker = ({ duration = 250, textStyle, textProps, children }: Props) => {
   };
 
   return (
-    <View style={styles.row}>
+    <View style={[styles.row, containerStyle]}>
       {measured === true &&
         Children.map(children, (child) => {
           if (typeof child === "string" || typeof child === "number") {


### PR DESCRIPTION
Currently there is no way to style the Ticker container, say if one wants to add a margin to the left or right of the Ticker without needing to wrap the ticker in another View it would be better to pass a style prop. 

Usually I would add the margin to the textStyle prop but since this components text / children is mapped to individual text components textStyle is applied to each meaning the margin is applied to each Text component.