### PR TITLE
Update peer dependencies to allow new versions of core dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ticker",
-  "version": "5.2.0",
+  "version": "6.0.1",
   "description": "React Native Number Ticker",
   "main": "index.js",
   "scripts": {
@@ -29,8 +29,8 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
-    "react-native": "^0.67.3",
-    "react-native-reanimated": "^2.4.1"
+    "react": ">= 16.9.0",
+    "react-native": ">= 0.67.3",
+    "react-native-reanimated": ">= 2.4.1"
   }
 }


### PR DESCRIPTION
Using the ^ for peer dependencies doesn't allow going up a major version, even if it's compatible.

Happy to put upper limits on these if you want, but React is supposed to be API compatible forever now!

Reanimated 3.x is API compatible with 2.x (except they removed the deprecated 1.x API now).